### PR TITLE
SCRIPTDOC-11: Pop ups above script bindings are not responsive

### DIFF
--- a/scripting-documentation-ui/src/main/resources/ScriptingDocumentation/ScriptDocPanel.xml
+++ b/scripting-documentation-ui/src/main/resources/ScriptingDocumentation/ScriptDocPanel.xml
@@ -850,7 +850,9 @@ require(['jquery','angular','angular-loading-bar'],
               return $(window).width() < 975 ? 'top' : 'left';
             }
           });
-          $(element).popover('toggle');
+          $(element).popover('show');
+        }, function(){
+          $(element).popover('hide');
         });
       }
     };

--- a/scripting-documentation-ui/src/main/resources/ScriptingDocumentation/ScriptDocPanel.xml
+++ b/scripting-documentation-ui/src/main/resources/ScriptingDocumentation/ScriptDocPanel.xml
@@ -845,9 +845,12 @@ require(['jquery','angular','angular-loading-bar'],
       restrict: 'A',
       link: function(scope, element, attrs){
         $(element).hover(function(){
-          $(element).popover('show');
-        }, function(){
-          $(element).popover('hide');
+          $(element).popover({
+            placement: function() {
+              return $(window).width() < 975 ? 'top' : 'left';
+            }
+          });
+          $(element).popover('toggle');
         });
       }
     };


### PR DESCRIPTION
https://jira.xwiki.org/projects/SCRIPTDOC/issues/SCRIPTDOC-11

With this, popups are now made to place on top when the screen size is small and thus are visible at every resolution.

Here's the output (for small screens):
![script-doc-11](https://user-images.githubusercontent.com/36920441/57478022-560e4900-72b3-11e9-909e-cf52166e8822.png)
